### PR TITLE
FEAT: Add sankey api

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A FastAPI-based service that provides data processing and API endpoints for gove
 
 ## 📋 Prerequisites
 
-- Python 3.8 or higher
+- Python 3.8 to 3.13
 - pip (Python package installer)
 - Git
 

--- a/src/routers/payload_incoming_router.py
+++ b/src/routers/payload_incoming_router.py
@@ -3,6 +3,8 @@ from src.models import ENTITY_PAYLOAD, ATTRIBUTE_PAYLOAD, WRITE_PAYLOAD
 from src.services import IncomingServiceAttributes, WriteAttributes
 from src.dependencies import get_config
 from chartFactory.utils import transform_data_for_chart
+from aiohttp import ClientSession, ClientTimeout
+from typing import AsyncGenerator
 
 router = APIRouter()
 # writer = WriteAttributes() 
@@ -13,23 +15,42 @@ def get_stat_service(config: dict = Depends(get_config)):
 def get_writer_service(config: dict = Depends(get_config)):
     return WriteAttributes(config)
 
+async def get_http_session() -> AsyncGenerator[ClientSession, None]:
+    timeout = ClientTimeout(total=90, connect=30, sock_connect=30, sock_read=90)
+    async with ClientSession(timeout=timeout) as session:
+        yield session
+
 @router.get("/allAttributes")
 async def get_all_attributes(statService: IncomingServiceAttributes = Depends(get_stat_service)):
     return statService.expose_all_attributes()
 @router.get("/categories")
-async def get_all_categories(id: str | None = None, statService: IncomingServiceAttributes = Depends(get_stat_service)):
-    return await statService.expose_category_by_id(id)
+async def get_all_categories(
+    id: str | None = None,
+    statService: IncomingServiceAttributes = Depends(get_stat_service),
+    session: ClientSession = Depends(get_http_session),
+):
+    return await statService.expose_category_by_id(id, session)
 
 # Get the relevant attributes for the entity
 @router.post("/data/entity/{entityId}")
-async def get_relevant_attributes_for_entity(ENTITY_PAYLOAD: ENTITY_PAYLOAD , entityId : str, statService: IncomingServiceAttributes = Depends(get_stat_service)):
-    attributes_of_the_entity = await statService.expose_relevant_attributes(ENTITY_PAYLOAD , entityId)
+async def get_relevant_attributes_for_entity(
+    ENTITY_PAYLOAD: ENTITY_PAYLOAD,
+    entityId : str,
+    statService: IncomingServiceAttributes = Depends(get_stat_service),
+    session: ClientSession = Depends(get_http_session),
+):
+    attributes_of_the_entity = await statService.expose_relevant_attributes(ENTITY_PAYLOAD , entityId, session)
     return attributes_of_the_entity
 
 # Get attributes for the selected attribute
 @router.post("/data/attribute/{entityId}")
-async def get_relevant_attributes_for_datasets(ATTRIBUTE_PAYLOAD: ATTRIBUTE_PAYLOAD, entityId : str, statService: IncomingServiceAttributes = Depends(get_stat_service)):
-    attribute_data_out = await statService.expose_data_for_the_attribute(ATTRIBUTE_PAYLOAD, entityId)   
+async def get_relevant_attributes_for_datasets(
+    ATTRIBUTE_PAYLOAD: ATTRIBUTE_PAYLOAD,
+    entityId : str,
+    statService: IncomingServiceAttributes = Depends(get_stat_service),
+    session: ClientSession = Depends(get_http_session),
+):
+    attribute_data_out = await statService.expose_data_for_the_attribute(ATTRIBUTE_PAYLOAD, entityId, session)
     return transform_data_for_chart(attribute_data_out)
 
 # Write attributes to the entities
@@ -56,12 +77,22 @@ async def write_metadata(writer: WriteAttributes = Depends(get_writer_service)):
     return writer.create_parent_categories_and_children_categories_v2(result)
 
 @router.get("/data/yearswithdata")
-async def yearswithdata(name: str, parentId: str, statService: IncomingServiceAttributes = Depends(get_stat_service)):
-    years = await statService.datacategoriesbyyear(name, parentId)
+async def yearswithdata(
+    name: str,
+    parentId: str,
+    statService: IncomingServiceAttributes = Depends(get_stat_service),
+    session: ClientSession = Depends(get_http_session),
+):
+    years = await statService.datacategoriesbyyear(name, parentId, session)
     return years
 
 @router.get("/data/orgchart/{entityId}/ministers-departments")
-async def get_ministers_and_departments(entityId: str, activeDate: str, statService: IncomingServiceAttributes = Depends(get_stat_service)):
+async def get_ministers_and_departments(
+    entityId: str,
+    activeDate: str,
+    statService: IncomingServiceAttributes = Depends(get_stat_service),
+    session: ClientSession = Depends(get_http_session),
+):
     """
     Test endpoint for get_ministers_and_departments function.
     
@@ -69,9 +100,7 @@ async def get_ministers_and_departments(entityId: str, activeDate: str, statServ
     - entityId: The entity ID to get ministers for (e.g., president ID)
     - activeDate: Date active (e.g., "2023-05-15")
     """
-    import aiohttp
-    async with aiohttp.ClientSession() as session:
-        result = await statService.get_ministers_and_departments(entityId, activeDate, session)
+    result = await statService.get_ministers_and_departments(entityId, activeDate, session)
     return result
 
 # Get the timeline for the orgchart

--- a/src/routers/payload_incoming_router.py
+++ b/src/routers/payload_incoming_router.py
@@ -4,7 +4,7 @@ from src.services import IncomingServiceAttributes, WriteAttributes
 from src.dependencies import get_config
 from chartFactory.utils import transform_data_for_chart
 from aiohttp import ClientSession, ClientTimeout
-from typing import AsyncGenerator
+from typing import AsyncGenerator, Sequence
 
 router = APIRouter()
 # writer = WriteAttributes() 
@@ -101,6 +101,16 @@ async def get_ministers_and_departments(
     - activeDate: Date active (e.g., "2023-05-15")
     """
     result = await statService.get_ministers_and_departments(entityId, activeDate, session)
+    return result
+
+@router.post("/data/orgchart/sankey/{entityId}")
+async def get_sankey_data(
+    entityId: str,
+    dates: Sequence[str],
+    statService: IncomingServiceAttributes = Depends(get_stat_service),
+    session: ClientSession = Depends(get_http_session),
+):
+    result = await statService.get_sankey_data(session, entityId, dates)
     return result
 
 # Get the timeline for the orgchart

--- a/src/routers/payload_incoming_router.py
+++ b/src/routers/payload_incoming_router.py
@@ -113,6 +113,15 @@ async def get_sankey_data(
     result = await statService.get_sankey_data(session, entityId, dates)
     return result
 
+@router.get("/data/orgchart/president/{presidentId}")
+async def get_president_tenure(
+    presidentId: str,
+    statService: IncomingServiceAttributes = Depends(get_stat_service),
+    session: ClientSession = Depends(get_http_session),
+):
+    result = await statService.get_president_tenure(presidentId, session)
+    return result
+
 # Get the timeline for the orgchart
 # @router.get("/data/orgchart/timeline")
 # async def get_timeline_for_orgchart(orgchartService: IncomingServiceOrgchart = Depends(get_orgchart_service)):

--- a/src/routers/payload_incoming_router.py
+++ b/src/routers/payload_incoming_router.py
@@ -60,6 +60,20 @@ async def yearswithdata(name: str, parentId: str, statService: IncomingServiceAt
     years = await statService.datacategoriesbyyear(name, parentId)
     return years
 
+@router.get("/data/orgchart/{entityId}/ministers-departments")
+async def get_ministers_and_departments(entityId: str, activeDate: str, statService: IncomingServiceAttributes = Depends(get_stat_service)):
+    """
+    Test endpoint for get_ministers_and_departments function.
+    
+    Parameters:
+    - entityId: The entity ID to get ministers for (e.g., president ID)
+    - activeDate: Date active (e.g., "2023-05-15")
+    """
+    import aiohttp
+    async with aiohttp.ClientSession() as session:
+        result = await statService.get_ministers_and_departments(entityId, activeDate, session)
+    return result
+
 # Get the timeline for the orgchart
 # @router.get("/data/orgchart/timeline")
 # async def get_timeline_for_orgchart(orgchartService: IncomingServiceOrgchart = Depends(get_orgchart_service)):

--- a/src/services/payload_incoming_attributes.py
+++ b/src/services/payload_incoming_attributes.py
@@ -605,8 +605,7 @@ class IncomingServiceAttributes:
         departments_by_ministers = {}
         expected_slots = len(dates)
         nodes: list[dict[str, str]] = []
-        seen_nodes: set[tuple[str | None, int]] = set()
-        # dates_list = list(dates)
+        node_indices: dict[tuple[str, int], int] = {} # key: (minister_id, date_index), value: node_index
 
         for date_index, result in enumerate(dates_gov_struct):
             if isinstance(result, Exception):
@@ -629,21 +628,27 @@ class IncomingServiceAttributes:
                     continue
 
                 # create nodes dict
-                node_key = (minister_id, date_index)
-                if minister_id and node_key not in seen_nodes:
-                    seen_nodes.add(node_key)
-                    nodes.append({
-                        "name": minister_id,
-                        "time": dates[date_index]
-                    })
+                node_index = None
+                if minister_id:
+                    node_key = (minister_id, date_index)
+                    node_index = node_indices.get(node_key)
+                    if node_index is None:
+                        node_index = len(nodes)
+                        node_indices[node_key] = node_index
+                        nodes.append({
+                            "name": minister_id,
+                            "time": dates[date_index]
+                        })
 
-                # create departments_by_ministers dict for comparison
+                # create departments_by_ministers dict for comparison:
+                #  key is the department
+                # value is the ministers index in the nodes list (for each date)
                 timeline = departments_by_ministers.get(department_id) # check if dept already in dict
                 if timeline is None:
                     timeline = [None] * expected_slots
                     departments_by_ministers[department_id] = timeline
 
-                timeline[date_index] = minister_id
+                timeline[date_index] = node_index
                 
                 
             

--- a/src/services/payload_incoming_attributes.py
+++ b/src/services/payload_incoming_attributes.py
@@ -552,7 +552,7 @@ class IncomingServiceAttributes:
             # Step 1: Get active ministers (sequential, must happen first)
             minister_ids = await self.get_active_ministers(entityId, dateActive, session)
 
-            print(f"Minister IDs: {minister_ids}")
+            # print(f"Minister IDs: {minister_ids}")
 
             if len(minister_ids) == 0:
                 return departments_results
@@ -573,7 +573,7 @@ class IncomingServiceAttributes:
                 if isinstance(result, list):
                     flattened_results.extend(result)
 
-            print(f"Flattened results length: {len(flattened_results)}")
+            # print(f"Flattened results length: {len(flattened_results)}")
             
             return flattened_results
             
@@ -662,10 +662,22 @@ class IncomingServiceAttributes:
             {"source": source, "target": target, "value": value}
             for (source, target), value in links_counter.items()
         ]
-        
+
         return {
             # "departmentsByMinisters": departments_by_ministers,
             "nodes": nodes,
             "links": links,
         }
 
+    async def get_president_tenure(self,presidentId, session):
+        url = f"{self.config['BASE_URL_QUERY']}/v1/entities/{presidentId}/relations"
+        headers = {"Content-Type": "application/json"}
+        payload = {
+            "name": "AS_PRESIDENT",
+        }
+        
+        async with session.post(url, json=payload, headers=headers) as response:
+            response.raise_for_status()
+            res_json = await response.json()
+            
+        return res_json

--- a/src/services/payload_incoming_attributes.py
+++ b/src/services/payload_incoming_attributes.py
@@ -593,15 +593,20 @@ class IncomingServiceAttributes:
         # [
         #     [
         #         {"ministerId": "minister-123", "departmentId": "dept-456"},
-        #         {"ministerId": "minister-123", "departmentId": "dept-789"},
+        #         {"ministerId": "minister-123", "departmentId": "dept-457"},
+        #         {"ministerId": "minister-456", "departmentId": "dept-789"},
         #     ],
         #     [
         #         {"ministerId": "minister-321", "departmentId": "dept-654"}
         #     ]
         # ]
         
+        # create comparison dictionary of departments by ministers
         departments_by_ministers = {}
         expected_slots = len(dates)
+        nodes: list[dict[str, str]] = []
+        seen_nodes: set[tuple[str | None, int]] = set()
+        # dates_list = list(dates)
 
         for date_index, result in enumerate(dates_gov_struct):
             if isinstance(result, Exception):
@@ -623,12 +628,25 @@ class IncomingServiceAttributes:
                 if not department_id:
                     continue
 
-                timeline = departments_by_ministers.get(department_id)
+                # create nodes dict
+                node_key = (minister_id, date_index)
+                if minister_id and node_key not in seen_nodes:
+                    seen_nodes.add(node_key)
+                    nodes.append({
+                        "name": minister_id,
+                        "time": dates[date_index]
+                    })
+
+                # create departments_by_ministers dict for comparison
+                timeline = departments_by_ministers.get(department_id) # check if dept already in dict
                 if timeline is None:
                     timeline = [None] * expected_slots
                     departments_by_ministers[department_id] = timeline
 
                 timeline[date_index] = minister_id
-
+                
+                
+            
+        print(f"Nodes: {nodes}")
         return departments_by_ministers
 


### PR DESCRIPTION
Add endpoints for creating a sankey diagram with ministers and departments.

Modify read endpoints using requests to use aiohttp instead.

Modify endpoints and service functions such that the session is created in the router and passed to each service call.