### PR TITLE
fix: inconsistent use of __init__.py

### DIFF
--- a/src/core/__init__.py
+++ b/src/core/__init__.py
@@ -1,0 +1,3 @@
+from .config import settings
+
+__all__ = ["settings"]

--- a/src/middleware/__init__.py
+++ b/src/middleware/__init__.py
@@ -1,0 +1,3 @@
+from .throttling import ThrottlingMiddleware
+
+__all__ = ["ThrottlingMiddleware"]

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -1,0 +1,4 @@
+from .http_client import HTTPClient, http_client
+from .util_functions import Util
+
+__all__ = ["HTTPClient", "http_client", "Util"]


### PR DESCRIPTION
Public classes/functions should be exposed via __init__.py. This PR adds missing __init__.py files in src/core, src/middleware, and src/utils to ensure consistent import patterns across the project. Fixes #101