### PR TITLE
FIX Internal server error when passes an invalid president ID  #115

### DIFF
--- a/src/services/opengin_service.py
+++ b/src/services/opengin_service.py
@@ -95,6 +95,8 @@ class OpenGINService:
                     raise BadRequestError(f"Read API Error: Bad request for id {entityId}")
                 response.raise_for_status()
                 data = await response.json()
+                if data is None:
+                    return []
                 result = [Relation.model_validate(item) for item in data]
                 return result
 

--- a/src/services/organisation_service.py
+++ b/src/services/organisation_service.py
@@ -199,6 +199,13 @@ class OrganisationService:
             raise BadRequestError("Selected date is required")
         
         try:
+            president_node_data = await self.opengin_service.get_entities(
+                entity=Entity(id=president_id)
+            )
+
+            if not president_node_data:
+                raise NotFoundError("President not found for the given ID")
+
             # First retrieve the relation list of the active portfolios under given president and given date  
             relation = Relation(name=RelationNameEnum.AS_MINISTER.value,activeAt=Util.normalize_timestamp(selected_date),direction=RelationDirectionEnum.OUTGOING.value)   
             activePortfolioList = await self.opengin_service.fetch_relation(

--- a/src/services/organisation_service.py
+++ b/src/services/organisation_service.py
@@ -199,12 +199,12 @@ class OrganisationService:
             raise BadRequestError("Selected date is required")
         
         try:
-            president_node_data = await self.opengin_service.get_entities(
-                entity=Entity(id=president_id)
-            )
-
-            if not president_node_data:
-                raise NotFoundError("President not found for the given ID")
+            try:
+                await self.opengin_service.get_entities(
+                    entity=Entity(id=president_id)
+                )
+            except NotFoundError as e:
+                raise NotFoundError("President not found for the given ID") from e
 
             # First retrieve the relation list of the active portfolios under given president and given date  
             relation = Relation(name=RelationNameEnum.AS_MINISTER.value,activeAt=Util.normalize_timestamp(selected_date),direction=RelationDirectionEnum.OUTGOING.value)   

--- a/src/services/organisation_service.py
+++ b/src/services/organisation_service.py
@@ -213,6 +213,20 @@ class OrganisationService:
                 relation=relation
             )
 
+            # A valid president may have no active portfolio relations for the
+            # selected date. Normalize a nullable upstream response and return
+            # the standard empty response without attempting portfolio processing.
+            activePortfolioList = activePortfolioList or []
+            if not activePortfolioList:
+                return {
+                    "NoOfCabinetMinistries": 0,
+                    "NoOfStateMinistries": 0,
+                    "newMinistries": 0,
+                    "newMinisters": 0,
+                    "ministriesUnderPresident": 0,
+                    "portfolioList": [],
+                }
+
             # Process each portfolio item in parallel
             results =await asyncio.gather(*[
                 self.process_portfolio_item(portfolio, president_id, selected_date)
@@ -233,7 +247,7 @@ class OrganisationService:
                 else:
                     successful_portfolios.append(results[i])
             
-            if len(exceptions) == len(results):
+            if results and len(exceptions) == len(results):
                 raise InternalServerError("Failed to process all portfolios")
             
             # Calculate final counts

--- a/test/test_opengin_service.py
+++ b/test/test_opengin_service.py
@@ -119,6 +119,24 @@ async def test_fetch_relation_success(mock_service, mock_session):
     assert result == [Relation(id="relation_123",relationName=RelationNameEnum.AS_MINISTER.value,direction=RelationDirectionEnum.OUTGOING.value)]
     mock_session.post.assert_called_once()
 
+@pytest.mark.asyncio
+async def test_fetch_relation_none_response_returns_empty_list(
+    mock_service, mock_session
+):
+    entity_id = "entity_123"
+    mock_session.post.return_value = MockResponse(None)
+
+    result = await mock_service.fetch_relation(
+        entity_id,
+        relation=Relation(
+            name=RelationNameEnum.AS_MINISTER.value,
+            direction=RelationDirectionEnum.OUTGOING.value,
+        ),
+    )
+
+    assert result == []
+    mock_session.post.assert_called_once()
+
 @pytest.mark.asyncio 
 async def test_fetch_relation_empty_entity_id(mock_service, mock_session):
     entity_id = ""
@@ -372,4 +390,3 @@ async def test_get_attributes_bad_request(mock_service, mock_session):
 
     with pytest.raises(BadRequestError, match="Bad request"):
         await mock_service.get_attributes("category_123", "dataset_abc")
-

--- a/test/test_organisation_service.py
+++ b/test/test_organisation_service.py
@@ -203,7 +203,7 @@ async def test_active_portfolio_list_invalid_president_id(
     president_id = "invalid_president_123"
     selected_date = "2021-10-27"
 
-    mock_opengin_service.get_entities.return_value = []
+    mock_opengin_service.get_entities.side_effect = NotFoundError("President not found")
 
     with pytest.raises(NotFoundError):
         await organisation_service.active_portfolio_list(

--- a/test/test_organisation_service.py
+++ b/test/test_organisation_service.py
@@ -1,7 +1,7 @@
 import pytest
 from unittest.mock import AsyncMock, patch, MagicMock
 from src.enums import EntityIdEnum, RelationDirectionEnum, RelationNameEnum
-from src.exception import BadRequestError, InternalServerError
+from src.exception import BadRequestError, InternalServerError, NotFoundError
 from src.models import Entity, Relation
 from src.utils import Util
 
@@ -193,6 +193,97 @@ async def test_enrich_department_item_not_new(
 
     mock_opengin_service.get_entities.assert_called_once_with(
         entity=Entity(id=department_relation.relatedEntityId)
+    )
+
+
+@pytest.mark.asyncio
+async def test_active_portfolio_list_invalid_president_id(
+    organisation_service, mock_opengin_service
+):
+    president_id = "invalid_president_123"
+    selected_date = "2021-10-27"
+
+    mock_opengin_service.get_entities.return_value = []
+
+    with pytest.raises(NotFoundError):
+        await organisation_service.active_portfolio_list(
+            president_id=president_id, selected_date=selected_date
+        )
+
+    mock_opengin_service.get_entities.assert_called_once_with(
+        entity=Entity(id=president_id)
+    )
+
+
+@pytest.mark.asyncio
+async def test_active_portfolio_list_valid_president_id(
+    organisation_service, mock_opengin_service
+):
+    president_id = "president_123"
+    selected_date = "2021-10-27"
+
+    mock_opengin_service.get_entities.return_value = [
+        Entity(id=president_id, name="mocked_protobuf_name")
+    ]
+    mock_opengin_service.fetch_relation.return_value = [
+        Relation(
+            id="portfolio_relation_123",
+            relatedEntityId="portfolio_123",
+            name=RelationNameEnum.AS_MINISTER.value,
+            startTime="2020-08-09T00:00:00Z",
+            endTime="2022-03-08T00:00:00Z",
+            direction=RelationDirectionEnum.OUTGOING.value,
+        )
+    ]
+
+    with patch(
+        "src.services.organisation_service.OrganisationService.process_portfolio_item",
+        new_callable=AsyncMock,
+    ) as mock_process_portfolio_item:
+        mock_process_portfolio_item.return_value = {
+            "id": "portfolio_123",
+            "name": "Portfolio X",
+            "type": "cabinetMinister",
+            "isNew": False,
+            "ministers": [],
+        }
+
+        result = await organisation_service.active_portfolio_list(
+            president_id=president_id, selected_date=selected_date
+        )
+
+    assert result == {
+        "NoOfCabinetMinistries": 1,
+        "NoOfStateMinistries": 0,
+        "newMinistries": 0,
+        "newMinisters": 0,
+        "ministriesUnderPresident": 0,
+        "portfolioList": [
+            {
+                "id": "portfolio_123",
+                "name": "Portfolio X",
+                "type": "cabinetMinister",
+                "isNew": False,
+                "ministers": [],
+            }
+        ],
+    }
+
+    mock_opengin_service.get_entities.assert_called_once_with(
+        entity=Entity(id=president_id)
+    )
+    mock_opengin_service.fetch_relation.assert_called_once_with(
+        entityId=president_id,
+        relation=Relation(
+            name=RelationNameEnum.AS_MINISTER.value,
+            activeAt=f"{selected_date}T00:00:00Z",
+            direction=RelationDirectionEnum.OUTGOING.value,
+        ),
+    )
+    mock_process_portfolio_item.assert_called_once_with(
+        mock_opengin_service.fetch_relation.return_value[0],
+        president_id,
+        selected_date,
     )
 
 

--- a/test/test_organisation_service.py
+++ b/test/test_organisation_service.py
@@ -288,6 +288,38 @@ async def test_active_portfolio_list_valid_president_id(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("relations", [None, []])
+async def test_active_portfolio_list_valid_president_without_active_relations(
+    organisation_service, mock_opengin_service, relations
+):
+    president_id = "president_123"
+    selected_date = "2021-10-27"
+
+    mock_opengin_service.get_entities.return_value = [
+        Entity(id=president_id, name="mocked_protobuf_name")
+    ]
+    mock_opengin_service.fetch_relation.return_value = relations
+
+    with patch(
+        "src.services.organisation_service.OrganisationService.process_portfolio_item",
+        new_callable=AsyncMock,
+    ) as mock_process_portfolio_item:
+        result = await organisation_service.active_portfolio_list(
+            president_id=president_id, selected_date=selected_date
+        )
+
+    assert result == {
+        "NoOfCabinetMinistries": 0,
+        "NoOfStateMinistries": 0,
+        "newMinistries": 0,
+        "newMinisters": 0,
+        "ministriesUnderPresident": 0,
+        "portfolioList": [],
+    }
+    mock_process_portfolio_item.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_departments_by_portfolio_id_success(
     organisation_service, mock_opengin_service
 ):


### PR DESCRIPTION
Summary

Fixes the `Internal Server Error` returned by the `active-portfolio-list` endpoint when an invalid president ID is passed as a query parameter.

Solution

Added a president existence validation at the beginning of the `try` block in the `active_portfolio_list` method, before fetching the active relationships.

- Calls `opengin_service.get_entities(Entity(id=president_id))` to verify the president exists
- If the entity is not found, raises a `NotFoundException` with a clear message instead of an unhandled `InternalServerError`
- If the entity is valid, proceeds with the existing logic unchanged