### PR TITLE
feat: Added contract for the proposed generic endpoint

### DIFF
--- a/gi_service/contract/rest/organisation_api_contract.yaml
+++ b/gi_service/contract/rest/organisation_api_contract.yaml
@@ -750,6 +750,84 @@ paths:
         "500":
           description: Server Error
 
+  /v1/entities-by-relation/{parent_id}:
+    post:
+      tags:
+        - Organization
+      summary: Get related entities in the organisation hierarchy.
+      description: Returns a list of entities related to the given parent entity by the given relation (e.g. AS_DEPARTMENT, AS_BODY) and a given date. The relation must be one of the relations supported for hierarchy traversal.
+      operationId: getEntitiesByRelation
+      parameters:
+        - name: parent_id
+          in: path
+          required: true
+          description: ID of the parent entity (e.g. a portfolio ID when relation=AS_DEPARTMENT, or a department ID when relation=AS_BODY).
+          schema:
+            type: string
+        - name: relation
+          in: query
+          required: true
+          description: Relation to traverse.
+          schema:
+            type: string
+            enum:
+              - AS_DEPARTMENT
+              - AS_BODY
+      requestBody:
+        required: true
+        description: This request body corresponds to the date used to retrieve the list of active related entities.
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Date"
+      responses:
+        "200":
+          description: Successfully returned
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  total:
+                    type: integer
+                  new:
+                    type: integer
+                  entityList:
+                    type: array
+                    items:
+                      type: object
+                      required:
+                        - name
+                        - id
+                      properties:
+                        name:
+                          type: string
+                        id:
+                          type: string
+                        isNew:
+                          type: boolean
+                        hasData:
+                          type: boolean
+
+              example:
+                total: 2
+                new: 1
+                entityList:
+                  - name: National Institute of Fisheries
+                    id: 2187-27_bod_4
+                    isNew: false
+                    hasData: true
+                  - name: Regional Fisheries Board
+                    id: 2153-12_bod_437
+                    isNew: true
+                    hasData: false
+        "400":
+          description: Bad request (e.g. unsupported relation)
+        "404":
+          description: Not found
+        "500":
+          description: Server Error
+
   /v1/departments-by-portfolio/{portfolio_id}:
     post:
       tags:

--- a/gi_service/contract/rest/organisation_api_contract.yaml
+++ b/gi_service/contract/rest/organisation_api_contract.yaml
@@ -750,83 +750,6 @@ paths:
         "500":
           description: Server Error
 
-  /v1/entities-by-relation/{parent_id}:
-    post:
-      tags:
-        - Organization
-      summary: Get related entities in the organisation hierarchy.
-      description: Returns a list of entities related to the given parent entity by the given relation (e.g. AS_DEPARTMENT, AS_BODY) and a given date. The relation must be one of the relations supported for hierarchy traversal.
-      operationId: getEntitiesByRelation
-      parameters:
-        - name: parent_id
-          in: path
-          required: true
-          description: ID of the parent entity (e.g. a portfolio ID when relation=AS_DEPARTMENT, or a department ID when relation=AS_BODY).
-          schema:
-            type: string
-        - name: relation
-          in: query
-          required: true
-          description: Relation to traverse.
-          schema:
-            type: string
-            enum:
-              - AS_DEPARTMENT
-              - AS_BODY
-      requestBody:
-        required: true
-        description: This request body corresponds to the date used to retrieve the list of active related entities.
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/Date"
-      responses:
-        "200":
-          description: Successfully returned
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  total:
-                    type: integer
-                  new:
-                    type: integer
-                  entityList:
-                    type: array
-                    items:
-                      type: object
-                      required:
-                        - name
-                        - id
-                      properties:
-                        name:
-                          type: string
-                        id:
-                          type: string
-                        isNew:
-                          type: boolean
-                        hasData:
-                          type: boolean
-
-              example:
-                total: 2
-                new: 1
-                entityList:
-                  - name: National Institute of Fisheries
-                    id: 2187-27_bod_4
-                    isNew: false
-                    hasData: true
-                  - name: Regional Fisheries Board
-                    id: 2153-12_bod_437
-                    isNew: true
-                    hasData: false
-        "400":
-          description: Bad request (e.g. unsupported relation)
-        "404":
-          description: Not found
-        "500":
-          description: Server Error
 
   /v1/departments-by-portfolio/{portfolio_id}:
     post:
@@ -1095,4 +1018,203 @@ components:
         name:
           type: string
         id:
+          type: string
+
+  /v1/organization/{above_id}:
+  post:
+    tags:
+      - Organization
+    summary: Get active list of related entities in the hierarchy one level below.
+    operationId: getEntityList
+
+    parameters:
+      - name: above_id
+        in: path
+        required: true
+        schema:
+          type: string
+
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - date
+              - relation
+            properties:
+              date:
+                type: string
+                format: date
+              relation:
+                type: string
+                enum:
+                  - PRESIDENT
+                  - MINISTER
+                  - DEPARTMENT
+                  - BODY
+
+    responses:
+      "200":
+        description: Successfully returned.
+        content:
+          application/json:
+            schema:
+              oneOf:
+                - $ref: "#/components/schemas/PresidentResponse"
+                - $ref: "#/components/schemas/MinisterResponse"
+                - $ref: "#/components/schemas/DepartmentResponse"
+                - $ref: "#/components/schemas/BodyResponse"
+              discriminator:
+                propertyName: relation
+                mapping:
+                  PRESIDENT: "#/components/schemas/PresidentResponse"
+                  MINISTER: "#/components/schemas/MinisterResponse"
+                  DEPARTMENT: "#/components/schemas/DepartmentResponse"
+                  BODY: "#/components/schemas/BodyResponse"
+
+      "400":
+        description: Bad request
+
+      "404":
+        description: Not found
+
+      "500":
+        description: Server error
+
+  components:
+    schemas:
+
+     BaseResponse:
+      type: object
+      required:
+        - relation
+        - body
+      properties:
+        relation:
+          type: string
+          enum:
+            - PRESIDENT
+            - MINISTER
+            - DEPARTMENT
+            - BODY
+
+    PresidentResponse:
+      allOf:
+        - $ref: "#/components/schemas/BaseResponse"
+        - type: object
+          properties:
+            body:
+              $ref: "#/components/schemas/PresidentBody"
+
+    MinisterResponse:
+      allOf:
+        - $ref: "#/components/schemas/BaseResponse"
+        - type: object
+          properties:
+            body:
+              $ref: "#/components/schemas/MinisterBody"
+
+    DepartmentResponse:
+      allOf:
+        - $ref: "#/components/schemas/BaseResponse"
+        - type: object
+          properties:
+            body:
+              $ref: "#/components/schemas/DepartmentBody"
+
+    BodyResponse:
+      allOf:
+        - $ref: "#/components/schemas/BaseResponse"
+        - type: object
+          properties:
+            body:
+              $ref: "#/components/schemas/BodyBody"
+
+    PresidentBody:
+      type: object
+      properties:
+        presidentList:
+          type: array
+          items:
+            $ref: "#/components/schemas/Entity"
+
+    MinisterBody:
+      type: object
+      properties:
+        ministerList:
+          type: array
+          items:
+            $ref: "#/components/schemas/Entity"
+
+    DepartmentBody:
+      type: object
+      properties:
+        departmentList:
+          type: array
+          items:
+            $ref: "#/components/schemas/Entity"
+
+    BodyBody:
+      type: object
+      properties:
+        portfolioList:
+          type: array
+          items:
+            $ref: "#/components/schemas/Portfolio"
+
+        activeMinistries:
+          type: integer
+
+        newMinistries:
+          type: integer
+
+        newMinisters:
+          type: integer
+
+        ministriesUnderPresident:
+          type: integer
+
+    Portfolio:
+      type: object
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        isNew:
+          type: boolean
+        ministers:
+          type: array
+          items:
+            $ref: "#/components/schemas/Minister"
+
+    Minister:
+      type: object
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        isPresident:
+          type: boolean
+        isNew:
+          type: boolean
+
+    Entity:
+      type: object
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: string
+        name:
           type: string

--- a/gi_service/contract/rest/organisation_api_contract.yaml
+++ b/gi_service/contract/rest/organisation_api_contract.yaml
@@ -1021,72 +1021,82 @@ components:
           type: string
 
   /v1/organization/{above_id}:
-  post:
-    tags:
-      - Organization
-    summary: Get active list of related entities in the hierarchy one level below.
-    operationId: getEntityList
+    post:
+      tags:
+        - Organization
+      summary: Get active list of related entities in the hierarchy one level below.
+      operationId: getEntityList
 
-    parameters:
-      - name: above_id
-        in: path
-        required: true
-        schema:
-          type: string
-
-    requestBody:
-      required: true
-      content:
-        application/json:
+      parameters:
+        - name: above_id
+          in: path
+          required: true
+          description: Id of the parent node in the hierarchy.
           schema:
-            type: object
-            required:
-              - date
-              - relation
-            properties:
-              date:
-                type: string
-                format: date
-              relation:
-                type: string
-                enum:
-                  - PRESIDENT
-                  - MINISTER
-                  - DEPARTMENT
-                  - BODY
+            type: string
 
-    responses:
-      "200":
-        description: Successfully returned.
+      requestBody:
+        required: true
         content:
           application/json:
             schema:
-              oneOf:
-                - $ref: "#/components/schemas/PresidentResponse"
-                - $ref: "#/components/schemas/MinisterResponse"
-                - $ref: "#/components/schemas/DepartmentResponse"
-                - $ref: "#/components/schemas/BodyResponse"
-              discriminator:
-                propertyName: relation
-                mapping:
-                  PRESIDENT: "#/components/schemas/PresidentResponse"
-                  MINISTER: "#/components/schemas/MinisterResponse"
-                  DEPARTMENT: "#/components/schemas/DepartmentResponse"
-                  BODY: "#/components/schemas/BodyResponse"
+              type: object
+              required:
+                - date
+                - relation
+              properties:
+                date:
+                  type: string
+                  format: date
+                relation:
+                  type: string
+                  enum:
+                    - MINISTER
+                    - DEPARTMENT
+                    - BODY
 
-      "400":
-        description: Bad request
+      responses:
+        "200":
+          description: Successfully returned.
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: "#/components/schemas/MinisterResponse"
+                  - $ref: "#/components/schemas/DepartmentResponse"
+                  - $ref: "#/components/schemas/BodyResponse"
+                discriminator:
+                  propertyName: relation
+                  mapping:
+                    MINISTER: "#/components/schemas/MinisterResponse"
+                    DEPARTMENT: "#/components/schemas/DepartmentResponse"
+                    BODY: "#/components/schemas/BodyResponse"
 
-      "404":
-        description: Not found
+        "400":
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
 
-      "500":
-        description: Server error
+        "404":
+          description: Not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
 
-  components:
-    schemas:
+        "500":
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
 
-     BaseResponse:
+components:
+  schemas:
+
+    BaseResponse:
       type: object
       required:
         - relation
@@ -1095,18 +1105,9 @@ components:
         relation:
           type: string
           enum:
-            - PRESIDENT
             - MINISTER
             - DEPARTMENT
             - BODY
-
-    PresidentResponse:
-      allOf:
-        - $ref: "#/components/schemas/BaseResponse"
-        - type: object
-          properties:
-            body:
-              $ref: "#/components/schemas/PresidentBody"
 
     MinisterResponse:
       allOf:
@@ -1132,14 +1133,6 @@ components:
             body:
               $ref: "#/components/schemas/BodyBody"
 
-    PresidentBody:
-      type: object
-      properties:
-        presidentList:
-          type: array
-          items:
-            $ref: "#/components/schemas/Entity"
-
     MinisterBody:
       type: object
       properties:
@@ -1155,6 +1148,14 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/Entity"
+	activeMinistries:
+          type: integer
+        newMinistries:
+          type: integer
+        newMinisters:
+          type: integer
+        ministriesUnderPresident:
+          type: integer
 
     BodyBody:
       type: object
@@ -1163,28 +1164,14 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/Portfolio"
-
-        activeMinistries:
-          type: integer
-
-        newMinistries:
-          type: integer
-
-        newMinisters:
-          type: integer
-
-        ministriesUnderPresident:
-          type: integer
+      
 
     Portfolio:
       type: object
       required:
         - id
-        - name
       properties:
         id:
-          type: string
-        name:
           type: string
         isNew:
           type: boolean
@@ -1197,11 +1184,8 @@ components:
       type: object
       required:
         - id
-        - name
       properties:
         id:
-          type: string
-        name:
           type: string
         isPresident:
           type: boolean
@@ -1212,9 +1196,17 @@ components:
       type: object
       required:
         - id
-        - name
       properties:
         id:
           type: string
-        name:
+
+    ErrorResponse:
+      type: object
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: string
+        message:
           type: string


### PR DESCRIPTION
## Summary

closes sub issue #123 

- Proposes a single generic endpoint, `POST /v1/entities-by-relation/{parent_id}?relation=...`, to replace having one endpoint per hierarchy level. It covers both existing `departments-by-portfolio`-style traversal and the newly needed department→body traversal, and any future level, without adding a new endpoint each time.
- `relation` is a query param constrained by an OpenAPI enum to `AS_DEPARTMENT` / `AS_BODY` — a deliberate whitelist so the endpoint can't be used to traverse unrelated relation types (e.g. `AS_APPOINTED`, `AS_PRESIDENT`).
- Response shape generalizes the existing `departments-by-portfolio` fields (`totalDepartments`/`newDepartments`/`departmentList`) into relation-agnostic `total`/`new`/`entityList`, so the same shape works for departments, bodies, or any future level.
- This PR is contract-only — no implementation yet. Opening it for API design review before writing the router/service code.

## Test plan
- [ ] Contract reviewed and approved
- [ ] `organisation_api_contract.yaml` validated to parse as valid OpenAPI YAML
